### PR TITLE
Allow tuna to output dir instead of spawning a server

### DIFF
--- a/tuna/cli.py
+++ b/tuna/cli.py
@@ -1,17 +1,35 @@
 # -*- coding: utf-8 -*-
 #
 import argparse
+import os.path
+import shutil
+import threading
+import webbrowser
 
 from .__about__ import __version__
-from .main import start_server
+from .main import start_server, read, render
 
 
 def main(argv=None):
     parser = _get_parser()
     args = parser.parse_args(argv)
 
-    start_server(args.infile, args.browser)
-    return
+    if args.outdir:
+        data = read(args.infile)
+        if not os.path.exists(args.outdir):
+            os.makedirs(args.outdir)
+        with open(os.path.join(args.outdir, 'index.html'), 'wt') as out:
+            out.write(render(data))
+        this_dir = os.path.dirname(__file__)
+        shutil.rmtree(os.path.join(args.outdir, "static"))
+        shutil.copytree(os.path.join(this_dir, "web", "static"),
+                        os.path.join(args.outdir, "static"))
+        if args.browser:
+            threading.Thread(
+                target=lambda: webbrowser.open_new_tab(args.outdir)
+            ).start()
+    else:
+        start_server(args.infile, args.browser)
 
 
 def _get_parser():
@@ -19,6 +37,13 @@ def _get_parser():
     parser = argparse.ArgumentParser(description=("Visualize Python profile."))
 
     parser.add_argument("infile", type=str, help="input runtime or import profile file")
+    parser.add_argument(
+        "-o", "--outdir",
+        default=None,
+        type=str,
+        help="output directory for static files. "
+             "No server is started if outdir is specified",
+    )
 
     parser.add_argument(
         "--no-browser",

--- a/tuna/main.py
+++ b/tuna/main.py
@@ -163,16 +163,20 @@ def read_import_profile(filename):
     return {"name": "main", "color": 0, "children": lst}
 
 
+def render(data):
+    return INDEX.substitute(
+        data=escape(json.dumps(data).replace("</", "<\\/")),
+        version=escape(__version__),
+    )
+
+
 def start_server(prof_filename, start_browser):
     data = read(prof_filename)
     data = data
 
     class IndexHandler(tornado.web.RequestHandler):
         def get(self):
-            self.write(INDEX.substitute(
-                data=escape(json.dumps(data).replace("</", "<\\/")),
-                version=escape(__version__),
-            ))
+            self.write(render(data))
 
     app = tornado.web.Application(
         [(r"/", IndexHandler)], static_path=os.path.join(this_dir, "web", "static")

--- a/tuna/web/index.html
+++ b/tuna/web/index.html
@@ -22,14 +22,14 @@
     <div class="container-fluid py-md-3">
       <div class="row">
         <div class="col">
-          <x-icicle data="{{data}}" row-height="100"></x-icicle>
+          <x-icicle data="${data}" row-height="100"></x-icicle>
         </div>
       </div>
     </div>
 
     <footer class="footer">
       <div class="container text-muted">
-        tuna v{{version}}
+        tuna v${version}
       </div>
     </footer>
 


### PR DESCRIPTION
This uses `string.Template` instead of tornado's templates because there are only two substitutions, no need for complex stuff.

I also would like to at least making tornado dependency optional. Even better use SimpleHTTPServer instead of tornado because a task is super simple and extra dependency doesn't really justified. But that's for the future.

Fixes #29 