### PR TITLE
Make logo path relative

### DIFF
--- a/tuna/web/index.html
+++ b/tuna/web/index.html
@@ -14,7 +14,7 @@
   <body>
     <nav class="navbar navbar-light bg-light">
       <a class="navbar-brand" href="https://github.com/nschloe/tuna">
-        <img src="/static/favicon256.png" width="30" height="30" class="d-inline-block align-top" alt="">
+        <img src="static/favicon256.png" width="30" height="30" class="d-inline-block align-top" alt="">
         tuna
       </a>
     </nav>


### PR DESCRIPTION
First, thanks for the awesome package! Already helped to do some benchmarks for [bio-phys/MDBenchmark](https://github.com/bio-phys/MDBenchmark/)!

- All file paths (CSS, JS) are referenced with `static/*`, whereas the logo is referenced as an absolute path via `/static/*`.
- If you want to deploy several `tuna` visualizations as subdirectories, referencing hte logo with `/static/*` will not work out of the box.
- This PR fixes this.