### PR TITLE
Fix for Python 3.6 not accepting pathlib.Path in mimetypes.guess_type

### DIFF
--- a/tuna/main.py
+++ b/tuna/main.py
@@ -226,7 +226,7 @@ def start_server(prof_filename, start_browser, port):
                 this_dir = Path(__file__).resolve().parent
                 filepath = this_dir / "web" / self.path[1:]
 
-                mimetype, _ = mimetypes.guess_type(filepath)
+                mimetype, _ = mimetypes.guess_type(str(filepath))
                 self.send_header("Content-type", mimetype)
                 self.end_headers()
 


### PR DESCRIPTION
This should close #73 

I noticed this exception on Python 3.6.7:

```python
Traceback (most recent call last):
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/socketserver.py", line 317, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/socketserver.py", line 348, in process_request
    self.finish_request(request, client_address)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/socketserver.py", line 721, in __init__
    self.handle()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/site-packages/tuna/main.py", line 230, in do_GET
    mimetype, _ = mimetypes.guess_type(filepath)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/mimetypes.py", line 291, in guess_type
    return _db.guess_type(url, strict)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/mimetypes.py", line 116, in guess_type
    scheme, url = urllib.parse.splittype(url)
  File "/Users/klauer/mc/envs/lucid/lib/python3.6/urllib/parse.py", line 938, in splittype
    match = _typeprog.match(url)
TypeError: expected string or bytes-like object
```

But not on Python 3.7.6. Replacing it with a string path fixes it for all versions.