### PR TITLE
Add IPython line / cell magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ To run the tuna unit tests, check out this repository and type
 pytest
 ```
 
+### IPython magics
+
+tuna includes a `tuna` line / cell magic which can be used as a drop-in replacement for the `prun` magic. Simply run `%load_ext tuna` to load the magic and then call it like `%tuna sleep(3)` or
+
+```python
+%%tuna
+sleep(3)
+```
+
+`prun` is still used to do the actual profiling and then the results are displayed in the notebook.
+
 ### Development
 
 After forking and cloning the repository, make sure to run `make dep` to install additional dependencies (bootstrap and d3) which aren't stored in the repo.

--- a/README.md
+++ b/README.md
@@ -98,5 +98,9 @@ To run the tuna unit tests, check out this repository and type
 pytest
 ```
 
+### Development
+
+After forking and cloning the repository, make sure to run `make dep` to install additional dependencies (bootstrap and d3) which aren't stored in the repo.
+
 ### License
 This software is published under the [GPLv3 license](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/tuna/__init__.py
+++ b/tuna/__init__.py
@@ -2,6 +2,9 @@ from . import cli
 from .__about__ import __version__
 from .main import read_import_profile
 
+def load_ipython_extension(ipython):
+    from . import magics
+
 __all__ = [
     "__version__",
     "cli",

--- a/tuna/__init__.py
+++ b/tuna/__init__.py
@@ -2,8 +2,10 @@ from . import cli
 from .__about__ import __version__
 from .main import read_import_profile
 
+
 def load_ipython_extension(ipython):
-    from . import magics
+    from . import magics  # noqa: F401
+
 
 __all__ = [
     "__version__",

--- a/tuna/magics.py
+++ b/tuna/magics.py
@@ -1,0 +1,57 @@
+import html
+import re
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from IPython.core.magic import register_line_cell_magic
+from IPython.display import HTML
+from IPython.utils.io import capture_output
+
+from .cli import main as tuna_main
+
+
+def _display_tuna(tuna_dir: str, row_height: int=60, iframe_height: int=500) -> HTML:
+    tuna_dir = Path(tuna_dir)
+    static_dir = tuna_dir / "static"
+
+    # in-line all of the css and js files
+    replacements = {
+        '<link rel="stylesheet" href="static/bootstrap.min.css">': "bootstrap.min.css",
+        '<link href="static/tuna.css" rel="stylesheet">': 'tuna.css',
+        '<script src="static/d3.min.js"></script>': 'd3.min.js',
+        '<script src="static/icicle.js"></script>': 'icicle.js',
+    }
+
+    page = (tuna_dir / "index.html").read_text()
+    page = re.sub(r"<nav.*</nav>", "", page, flags=re.DOTALL)
+    page = re.sub(r"<footer.*</footer>", "", page, flags=re.DOTALL)
+    page = page.replace('row-height="100"', f'row-height="{row_height}"')
+
+    for rep_string, rep_fname in replacements.items():
+        asset = (static_dir / rep_fname).read_text()
+        if rep_fname.endswith(".js"):
+            asset = f"<script>{asset}</script>"
+        elif rep_fname.endswith(".css"):
+            asset = f"<style>{asset}</style>"
+        page = page.replace(rep_string, asset)
+    # Use `HTML` with an iframe inside rather than just `IFrame` so that we don't have
+    # to write out an html file and ensure it's not deleted before the results are
+    # displayed
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        return HTML(f"""<iframe srcdoc="{html.escape(page)}" style="border: 0" width="100%" height={iframe_height}></iframe>""")
+
+
+@register_line_cell_magic
+def tuna(line: str, cell: Optional[str]=None) -> HTML:
+    ip = get_ipython()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        prun_fname = f"{tmp_dir}/prun"
+        prun_line = f"-q -D {prun_fname}"
+        with capture_output():
+            ip.run_cell_magic("prun", prun_line, cell if cell is not None else line)
+        args = [prun_fname, "-o", tmp_dir, "--no-browser"]
+        tuna_main(args)
+        return _display_tuna(tmp_dir)

--- a/tuna/magics.py
+++ b/tuna/magics.py
@@ -12,7 +12,7 @@ from IPython.utils.io import capture_output
 from .cli import main as tuna_main
 
 
-def _display_tuna(tuna_dir: str, row_height: int=60, iframe_height: int=500) -> HTML:
+def _display_tuna(tuna_dir: str, row_height: int = 60, iframe_height: int = 500) -> HTML:
     tuna_dir = Path(tuna_dir)
     static_dir = tuna_dir / "static"
 
@@ -45,8 +45,8 @@ def _display_tuna(tuna_dir: str, row_height: int=60, iframe_height: int=500) -> 
 
 
 @register_line_cell_magic
-def tuna(line: str, cell: Optional[str]=None) -> HTML:
-    ip = get_ipython()
+def tuna(line: str, cell: Optional[str] = None) -> HTML:
+    ip = get_ipython()  # noqa: F821
     with tempfile.TemporaryDirectory() as tmp_dir:
         prun_fname = f"{tmp_dir}/prun"
         prun_line = f"-q -D {prun_fname}"

--- a/tuna/magics.py
+++ b/tuna/magics.py
@@ -12,16 +12,18 @@ from IPython.utils.io import capture_output
 from .cli import main as tuna_main
 
 
-def _display_tuna(tuna_dir: str, row_height: int = 60, iframe_height: int = 500) -> HTML:
+def _display_tuna(
+    tuna_dir: str, row_height: int = 60, iframe_height: int = 500
+) -> HTML:
     tuna_dir = Path(tuna_dir)
     static_dir = tuna_dir / "static"
 
     # in-line all of the css and js files
     replacements = {
         '<link rel="stylesheet" href="static/bootstrap.min.css">': "bootstrap.min.css",
-        '<link href="static/tuna.css" rel="stylesheet">': 'tuna.css',
-        '<script src="static/d3.min.js"></script>': 'd3.min.js',
-        '<script src="static/icicle.js"></script>': 'icicle.js',
+        '<link href="static/tuna.css" rel="stylesheet">': "tuna.css",
+        '<script src="static/d3.min.js"></script>': "d3.min.js",
+        '<script src="static/icicle.js"></script>': "icicle.js",
     }
 
     page = (tuna_dir / "index.html").read_text()
@@ -41,7 +43,16 @@ def _display_tuna(tuna_dir: str, row_height: int = 60, iframe_height: int = 500)
     # displayed
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
-        return HTML(f"""<iframe srcdoc="{html.escape(page)}" style="border: 0" width="100%" height={iframe_height}></iframe>""")
+        return HTML(
+            f"""
+            <iframe
+              srcdoc="{html.escape(page)}"
+              style="border: 0"
+              width="100%"
+              height={iframe_height}>
+            </iframe>
+            """
+        )
 
 
 @register_line_cell_magic


### PR DESCRIPTION
This adds a magic so that tuna can be used inside of Jupyter notebooks with the plot embedded in the notebook (in an iframe). The actual profiling is done by the existing `prun` magic (this is also whatthe SnakeViz magic does).

I also added a note to the README about the magics and to help future developers (I was hitting errors for awhile because I didn't realize I needed to install boostrap and d3).

Fixes #72.