### PR TITLE
Remove shortcut from favicon link

### DIFF
--- a/tuna/web/index.html
+++ b/tuna/web/index.html
@@ -5,7 +5,7 @@
     <title>tuna - ${filename}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="shortcut icon" type="image/png" href="static/favicon256.png" />
+    <link rel="icon" type="image/png" href="static/favicon256.png" />
 
     <link href="static/tuna.css" rel="stylesheet" />
     <link rel="stylesheet" href="static/bootstrap.min.css" />


### PR DESCRIPTION
As explained in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel), the shortcut link type is often seen before icon, but this link type is non-conforming, ignored and web authors must not use it anymore.

This PR might solve https://github.com/nschloe/tuna/issues/115