### PR TITLE
Fix dependencies installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ the notebook.
 
 ### Development
 
-After forking and cloning the repository, make sure to run `make dep` to install
+After forking and cloning the repository, make sure to run `just dep` to install
 additional dependencies (bootstrap and d3) which aren't stored in the repo.
 
 ### License


### PR DESCRIPTION
They mention `make`, but this project uses `just`.