### PR TITLE
Typos in commands at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ below) and is faster, too.
 Create a runtime profile with
 
 ```
-python -mcProfile -o program.prof yourfile.py
+python -m cProfile -o program.prof yourfile.py
 ```
 
 or an [import
@@ -35,7 +35,7 @@ profile](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPROFILEIMPORT
 with
 
 ```
-python -X importtime yourfile.py 2> import.log
+python -X import time yourfile.py 2> import.log
 ```
 
 and show it with

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ profile](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPROFILEIMPORT
 with
 
 ```
-python -X import time yourfile.py 2> import.log
+python -X importtime yourfile.py 2> import.log
 ```
 
 and show it with


### PR DESCRIPTION
Just fixing some typos in the commands shown in the README.md