### PR TITLE
Fix `--outdir` to pass a `str` to `webbrowser.open_new_tab()`

### DIFF
--- a/tuna/cli.py
+++ b/tuna/cli.py
@@ -26,7 +26,7 @@ def main(argv=None):
         shutil.copytree(this_dir / "web" / "static", static_dir)
         if args.browser:
             threading.Thread(
-                target=lambda: webbrowser.open_new_tab(outdir / "index.html")
+                target=lambda: webbrowser.open_new_tab(str(outdir / "index.html"))
             ).start()
     else:
         start_server(args.infile, args.browser, args.port)

--- a/tuna/cli.py
+++ b/tuna/cli.py
@@ -34,7 +34,7 @@ def main(argv=None):
 
 def _get_parser():
     """Parse input options."""
-    parser = argparse.ArgumentParser(description=("Visualize Python profile."))
+    parser = argparse.ArgumentParser(description="Visualize Python profile.")
 
     parser.add_argument("infile", type=str, help="input runtime or import profile file")
     parser.add_argument(
@@ -66,6 +66,6 @@ def _get_parser():
         "--version",
         "-v",
         action="version",
-        version="%(prog)s " + (f"(version {__version__})"),
+        version="%(prog)s " + f"(version {__version__})",
     )
     return parser


### PR DESCRIPTION
```pytb
❯ python --version
Python 3.12.4
❯ python -X importtime -c 'import pprint' 2> import.log && tuna import.log -o /tmp/tuna-html
Exception in thread Thread-1 (<lambda>):
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/tuna/cli.py", line 29, in <lambda>
    target=lambda: webbrowser.open_new_tab(outdir / "index.html")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/webbrowser.py", line 103, in open_new_tab
    return open(url, 2)
           ^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/webbrowser.py", line 87, in open
    if browser.open(url, new, autoraise):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/webbrowser.py", line 639, in open
    script = 'open location "%s"' % url.replace('"', '%22') # opens in default browser
                                    ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Path.replace() takes 2 positional arguments but 3 were given
```

This is because `webbrowser.open_new_tab(url)` expects `url` to be a `str`, not a `pathlib.Path`.

Also remove some redundant parentheses.