### PR TITLE
Update pre-commit to fix lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 7.0.0
     hooks:
       - id: isort
 
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.3.0
     hooks:
       - id: flake8

--- a/tuna/magics.py
+++ b/tuna/magics.py
@@ -44,16 +44,14 @@ def _display_tuna(
     # displayed
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
-        return HTML(
-            f"""
+        return HTML(f"""
             <iframe
               srcdoc="{html.escape(page)}"
               style="border: 0"
               width="100%"
               height={iframe_height}>
             </iframe>
-            """
-        )
+            """)
 
 
 @register_line_cell_magic


### PR DESCRIPTION
The lint CI is failing on PRs such as https://github.com/nschloe/tuna/pull/161 due to old and conflicting dependencies.