### PR TITLE
Use ThreadingHTTPServer to fix deadlock on concurrent requests

### DIFF
--- a/tuna/main.py
+++ b/tuna/main.py
@@ -5,7 +5,7 @@ import socket
 import string
 import threading
 import webbrowser
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from .__about__ import __version__
@@ -69,7 +69,7 @@ def start_server(prof_filename, start_browser, port):
         while is_port_in_use(port):
             port += 1
 
-    httpd = HTTPServer(("", port), StaticServer)
+    httpd = ThreadingHTTPServer(("", port), StaticServer)
 
     if start_browser:
         address = f"http://localhost:{port}"


### PR DESCRIPTION
tuna's server mode uses `HTTPServer` (single-threaded) with HTTP/1.1. When a browser loads a page it sends concurrent requests (HTML + CSS + JS + favicon), and the single-threaded server deadlocks on HTTP keep-alive connections — it blocks reading for a follow-up request on one connection instead of accepting the next queued connection.

This switches to `ThreadingHTTPServer` (which `python -m http.server` also uses) so each connection is handled in its own thread.

Fixes #178