### PR TITLE
Include deps in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-node@v4
+      - uses: extractions/setup-just@v2
+      - run: just dep
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Thank you for the new 0.5.12 release!

It's missing the bootstrap.min.css and d3.min.js deps:

```console
❯ python -X importtime -c "import random" 2> 1.log
```
```pytb
❯ tuna 1.log
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET /static/tuna.css HTTP/1.1" 200 -
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET /static/bootstrap.min.css HTTP/1.1" 200 -
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET /static/d3.min.js HTTP/1.1" 200 -
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET /static/icicle.js HTTP/1.1" 200 -
----------------------------------------
127.0.0.1 - - [11/Apr/2026 23:29:35] "GET /static/favicon256.png HTTP/1.1" 200 -
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 57522)
Exception occurred during processing of request from ('127.0.0.1', 57521)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 697, in process_request_thread
    self.finish_request(request, client_address)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 766, in __init__
    self.handle()
    ~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/http/server.py", line 496, in handle
    self.handle_one_request()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/http/server.py", line 484, in handle_one_request
    method()
    ~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/tuna/main.py", line 65, in do_GET
    with filepath.open("rb") as fh:
         ~~~~~~~~~~~~~^^^^^^
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib/__init__.py", line 771, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/tuna/web/static/bootstrap.min.css'
----------------------------------------
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 697, in process_request_thread
    self.finish_request(request, client_address)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/socketserver.py", line 766, in __init__
    self.handle()
    ~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/http/server.py", line 496, in handle
    self.handle_one_request()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/http/server.py", line 484, in handle_one_request
    method()
    ~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/tuna/main.py", line 65, in do_GET
    with filepath.open("rb") as fh:
         ~~~~~~~~~~~~~^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/pathlib/__init__.py", line 771, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Library/Frameworks/Python.framework/Versions/3.14/lib/python3.14/site-packages/tuna/web/static/d3.min.js'
----------------------------------------
```

These are normally provided by running `just dep`, so I think we need to do that in the release workflow.

Note: I've not tested this.