### PR TITLE
Fix opening file when `--outdir`

### DIFF
--- a/src/tuna/cli.py
+++ b/src/tuna/cli.py
@@ -1,6 +1,5 @@
 import argparse
 import shutil
-import threading
 import webbrowser
 from pathlib import Path
 
@@ -25,9 +24,7 @@ def main(argv=None):
             shutil.rmtree(static_dir)
         shutil.copytree(this_dir / "web" / "static", static_dir)
         if args.browser:
-            threading.Thread(
-                target=lambda: webbrowser.open_new_tab(str(outdir / "index.html")),
-            ).start()
+            webbrowser.open_new_tab((outdir / "index.html").resolve().as_uri())
     else:
         start_server(args.infile, args.browser, args.port)
 


### PR DESCRIPTION
On macOS, when I run:

```sh
tuna import.log --outdir /tmp/my-dir
```

It only opens a blank `about:blank` page in Chrome.

This is because it's trying to do `webbrowser.open_new_tab("/tmp/my-dir/index.html")` but it needs the `file://` protocol, so `.as_uri()`. And we'd better `.resolve()` in case of relative dirs.

Also, we don't `threading.Thread()` here, because it opens the URL without blocking, and exits. Removing it also makes it faster.
