### PR TITLE
Add "Copy" button

### DIFF
--- a/src/tuna/web/index.html
+++ b/src/tuna/web/index.html
@@ -54,7 +54,7 @@
                   Export PNG
                 </button>
                 <button class="btn btn-outline-dark" id="copyPngButton">
-                  Copy
+                  Copy PNG
                 </button>
               </div>
             </div>

--- a/src/tuna/web/index.html
+++ b/src/tuna/web/index.html
@@ -53,6 +53,9 @@
                 <button class="btn btn-outline-dark" id="exportPngButton">
                   Export PNG
                 </button>
+                <button class="btn btn-outline-dark" id="copyPngButton">
+                  Copy
+                </button>
               </div>
             </div>
           </div>

--- a/src/tuna/web/static/icicle.js
+++ b/src/tuna/web/static/icicle.js
@@ -20,12 +20,16 @@ class Icicle extends HTMLElement {
   setupExportButtons() {
     const svgButton = document.getElementById("exportSvgButton");
     const pngButton = document.getElementById("exportPngButton");
+    const copyButton = document.getElementById("copyPngButton");
 
     if (svgButton) {
       svgButton.addEventListener("click", () => this.exportSvg());
     }
     if (pngButton) {
       pngButton.addEventListener("click", () => this.exportPng());
+    }
+    if (copyButton) {
+      copyButton.addEventListener("click", () => this.copyPng(copyButton));
     }
   }
 
@@ -108,7 +112,7 @@ class Icicle extends HTMLElement {
     URL.revokeObjectURL(url);
   }
 
-  exportPng() {
+  getPngBlob() {
     const clone = this.getSvgWithInlinedStyles();
     const serializer = new XMLSerializer();
     const svgString = serializer.serializeToString(clone);
@@ -123,29 +127,68 @@ class Icicle extends HTMLElement {
     const ctx = canvas.getContext("2d");
     ctx.scale(scale, scale);
 
-    const img = new Image();
     const svgBlob = new Blob([svgString], { type: "image/svg+xml" });
     const url = URL.createObjectURL(svgBlob);
 
-    img.onload = () => {
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(0, 0, width, height);
-      ctx.drawImage(img, 0, 0);
-      URL.revokeObjectURL(url);
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => {
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, width, height);
+        ctx.drawImage(img, 0, 0);
+        URL.revokeObjectURL(url);
+        canvas.toBlob((blob) => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            reject(new Error("Failed to create PNG blob"));
+          }
+        }, "image/png");
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        reject(new Error("Failed to load SVG image"));
+      };
+      img.src = url;
+    });
+  }
 
-      canvas.toBlob((blob) => {
-        const pngUrl = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = pngUrl;
-        a.download = `${this.exportBaseName}.png`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(pngUrl);
-      }, "image/png");
+  exportPng() {
+    this.getPngBlob().then((blob) => {
+      const pngUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = pngUrl;
+      a.download = `${this.exportBaseName}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(pngUrl);
+    });
+  }
+
+  copyPng(button) {
+    const originalText = button.textContent;
+    const restore = () => {
+      setTimeout(() => {
+        button.textContent = originalText;
+      }, 1500);
     };
-
-    img.src = url;
+    // ClipboardItem accepts a Promise so Safari permits async blob generation
+    // inside the user-gesture handler.
+    const item = new ClipboardItem({
+      "image/png": this.getPngBlob(),
+    });
+    navigator.clipboard
+      .write([item])
+      .then(() => {
+        button.textContent = "Copied!";
+        restore();
+      })
+      .catch((err) => {
+        console.error("Failed to copy PNG to clipboard:", err);
+        button.textContent = "Copy failed";
+        restore();
+      });
   }
 
   get width() {


### PR DESCRIPTION
This adds a copy button like this:

<img width="1470" height="647" alt="image" src="https://github.com/user-attachments/assets/6e59b196-c59a-4afc-8926-a96e29902317" />

So we copy the chart and easily paste it from the clipboard like this:

<img width="2434" height="1090" alt="image" src="https://github.com/user-attachments/assets/7edf0b04-5233-4d6b-8592-b27bbfb69fb9" />

Tested on Chrome, Safari and Firefox on macOS.